### PR TITLE
removed  requirement fxp/composer-asset-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         }
     ],
     "require": {
-        "fxp/composer-asset-plugin": "*",
-        "yiisoft/yii2": "*"
+        "yiisoft/yii2": "^2.0.14"
     },
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Composer-asset  not need in new versions of yii2